### PR TITLE
Add -fast to the default flags

### DIFF
--- a/autoload/fmt.vim
+++ b/autoload/fmt.vim
@@ -5,7 +5,7 @@ if !exists('g:crlfmt_fail_silently')
 endif
 
 if !exists('g:crlfmt_options')
-    let g:crlfmt_options = ' -ignore ".*.pb(.gw)?.go" -tab 2'
+    let g:crlfmt_options = ' -ignore ".*.pb(.gw)?.go" -tab 2 -fast'
 endif
 
 " Below function is copied from vim-go's fmt.vim file.


### PR DESCRIPTION
Crlfmt now runs goimports unless the -fast flag is used. This causes problems because we're running it on a file in the temp directory. It's also not necessary since vim-go runs goimports anyway, so it would just run twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/irfansharif/vim-crlfmt/1)
<!-- Reviewable:end -->
