### PR TITLE
use a temporary file in the same directory

### DIFF
--- a/autoload/fmt.vim
+++ b/autoload/fmt.vim
@@ -23,7 +23,7 @@ function! fmt#Format()
     let l:curw=winsaveview()
 
     " Write current unsaved buffer to a temp file
-    let l:tmpname = tempname() . ".go"
+    let l:tmpname = expand('%') . ".tmp.go"
     call writefile(getline(1, '$'), l:tmpname)
 
     let fmt_command = "crlfmt"


### PR DESCRIPTION
I found that this plugin removes imports where the directory name
doesn't match the package name. It looks like crlfmt behaves
differently when the file is under `/tmp`.

This commit changes the plugin to create a temporary file in the same
directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/irfansharif/vim-crlfmt/2)
<!-- Reviewable:end -->
