### PR TITLE
use silent and redraw screen

### DIFF
--- a/autoload/fmt.vim
+++ b/autoload/fmt.vim
@@ -32,7 +32,8 @@ function! fmt#Format()
     let command = fmt_command . ' -w ' . g:crlfmt_options
 
     " execute our command...
-    let out = system(command . " " . l:tmpname)
+    silent let out = system(command . " " . l:tmpname)
+    redraw!
 
     " if there is no error on the temp file replace the output with the
     " current file.


### PR DESCRIPTION
The system command causes some stray garbage characters to show up in my terminal. Adding `silent` fixes some but not all. The `redraw!` at least cleans them up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/irfansharif/vim-crlfmt/4)
<!-- Reviewable:end -->
